### PR TITLE
CNAME Setup

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-
+www.spiredigital.uk


### PR DESCRIPTION
This changes the CNAME to allow for the spiredigital.uk domain to be
used